### PR TITLE
bazel: Mark pip extension as a development dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,7 +26,7 @@ python.toolchain(
 )
 use_repo(python)
 
-pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip", dev_dependency = True)
 pip.parse(
     hub_name = "pip_score_venv_test",
     python_version = PYTHON_VERSION,


### PR DESCRIPTION
pip “hub” names from rules_python must be globally unique across the whole Bazel module graph.
pip_score_venv_test conflicts with other repos, which makes integration impossible. I'll create appropriate PRs there as well.
I assume no-one outside this repo needs pip_score_venv_test.
So make it local only.

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] PR title is short, expressive and meaningful
* [x] Commits are properly organized
* [x] Relevant issues are linked in the [References](#references) section
* [x] Tests are conducted
* [x] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes # <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
