### PR TITLE
fix: preserve program insertion order in OrchProgramManager

### DIFF
--- a/src/orchestration/src/api/design.rs
+++ b/src/orchestration/src/api/design.rs
@@ -169,7 +169,7 @@ impl Design {
         shutdown_events: &GrowableVec<ShutdownEvent>,
         container: &mut GrowableVec<Program>,
     ) -> Result<(), CommonErrors> {
-        while let Some(program_data) = self.programs.pop() {
+        while let Some(program_data) = self.programs.remove(0) {
             let mut builder = ProgramBuilder::new(program_data.0);
             (program_data.1)(&mut self, &mut builder)?;
             container.push(builder.build(shutdown_events, self.config())?);

--- a/src/orchestration/src/api/mod.rs
+++ b/src/orchestration/src/api/mod.rs
@@ -166,7 +166,7 @@ impl OrchestrationApi<_DesignTag> {
     /// Returns an error if there is an issue while creating the programs, such as a design not being valid.
     pub fn into_program_manager(mut self) -> Result<OrchProgramManager, CommonErrors> {
         let mut programs = GrowableVec::default();
-        while let Some(design) = self.designs.pop() {
+        while let Some(design) = self.designs.remove(0) {
             design.into_programs(&self.shutdown_events, &mut programs)?
         }
 

--- a/tests/test_cases/tests/orchestrator/test_graph.py
+++ b/tests/test_cases/tests/orchestrator/test_graph.py
@@ -371,10 +371,13 @@ class TestGraphInConcurrency(CommonGraphProgramConfig):
 
 
 class TestGraphInSeparatePrograms(CommonGraphProgramConfig):
+    @pytest.fixture(scope="class")
+    def scenario_name(self) -> str:
+        return "orchestration.graphs.integration_graph"
+
     def graph_name(self) -> str:
         return "two_programs"
 
-    @pytest.mark.xfail(reason="https://github.com/qorix-group/inc_orchestrator_internal/issues/382")
     def test_valid(self, logs_nodes: LogContainer):
         n0 = logs_nodes.find_log(field="message", pattern="node0 was executed")
         n1 = logs_nodes.find_log(field="message", pattern="node1 was executed")


### PR DESCRIPTION
## Summary
- Fixed `into_program_manager()` in `api/mod.rs` using `pop()` (LIFO) instead of `remove(0)` (FIFO) when processing designs, causing reversed order
- Fixed the same bug in `Design::into_programs()` in `api/design.rs` where programs within a design were also popped in reverse order
- Updated `TestGraphInSeparatePrograms` test to use `integration_graph` scenario (runs all programs) instead of `graph_program` (runs only one)
- Removed `@pytest.mark.xfail` marker from the test since the bug is now fixed

## Test plan
- [x] `bazel test //...` — all 6 test targets PASS (including previously xfail `TestGraphInSeparatePrograms::test_valid`)
- [x] `bazel build //...` — full build SUCCESS
- [x] Format checks (rustfmt, ruff, buildifier, yamlfmt) — all PASSED

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)