### PR TITLE
bazel: fix visibility of examples

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -13,54 +13,65 @@
 alias(
     name = "basic",
     actual = "//src/orchestration:basic",
+    visibility = ["//visibility:public"],
 )
 
 alias(
     name = "main_macro_basic",
     actual = "//src/orchestration:main_macro_basic",
+    visibility = ["//visibility:public"],
 )
 
 alias(
     name = "branching",
     actual = "//src/orchestration:branching",
+    visibility = ["//visibility:public"],
 )
 
 alias(
     name = "catch_error",
     actual = "//src/orchestration:catch_error",
+    visibility = ["//visibility:public"],
 )
 
 alias(
     name = "dag",
     actual = "//src/orchestration:dag",
+    visibility = ["//visibility:public"],
 )
 
 alias(
     name = "events_across_local_programs",
     actual = "//src/orchestration:events_across_local_programs",
+    visibility = ["//visibility:public"],
 )
 
 alias(
     name = "shutdown",
     actual = "//src/orchestration:shutdown",
+    visibility = ["//visibility:public"],
 )
 
 alias(
     name = "shutdown_using_signals",
     actual = "//src/orchestration:shutdown_using_signals",
+    visibility = ["//visibility:public"],
 )
 
 alias(
     name = "inter_process_event_sender",
     actual = "//src/orchestration:inter_process_event_sender",
+    visibility = ["//visibility:public"],
 )
 
 alias(
     name = "inter_process_event_receiver",
     actual = "//src/orchestration:inter_process_event_receiver",
+    visibility = ["//visibility:public"],
 )
 
 alias(
     name = "camera_drv_object_det",
     actual = "//src/orchestration/examples/camera_drv_object_det:camera_drv_object_det",
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
make them public for reference_integration

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [ ] PR title is short, expressive and meaningful
* [ ] Commits are properly organized
* [ ] Relevant issues are linked in the [References](#references) section
* [ ] Tests are conducted
* [ ] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes https://github.com/eclipse-score/reference_integration/issues/139
<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
