### PR TITLE
fix vscode setting for rust analyzer issue

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -105,9 +105,7 @@
             150
         ]
     },
-    "rust-analyzer.cargo.features": [
-        "qm"
-    ],
+    "rust-analyzer.cargo.features": [],
     "rust-analyzer.cargo.cfgs": [
         "!miri"
     ],


### PR DESCRIPTION
**Description:**
This pull request resolves a persistent startup failure with rust-analyzer and improves the consistency of the development environment.

**What was the problem?**
The rust-analyzer language server was failing to initialize because it was configured to use a Cargo feature named qm which does not exist in any of the workspace crates. This was caused by an incorrect entry in .vscode/settings.json.
