### PR TITLE
Fix: OrchProgramManager stores programs in reversed order

### DIFF
--- a/src/orchestration/src/api/design.rs
+++ b/src/orchestration/src/api/design.rs
@@ -169,7 +169,7 @@ impl Design {
         shutdown_events: &GrowableVec<ShutdownEvent>,
         container: &mut GrowableVec<Program>,
     ) -> Result<(), CommonErrors> {
-        while let Some(program_data) = self.programs.pop() {
+        while let Some(program_data) = self.programs.remove(0) {
             let mut builder = ProgramBuilder::new(program_data.0);
             (program_data.1)(&mut self, &mut builder)?;
             container.push(builder.build(shutdown_events, self.config())?);
@@ -275,6 +275,40 @@ mod tests {
         // Attempt to retrieve a non-existent orchestration tag
         let orchestration_tag = design.get_orchestration_tag(tag);
         assert!(orchestration_tag.is_err());
+    }
+
+    #[test]
+    fn into_programs_preserves_insertion_order() {
+        use crate::prelude::Invoke;
+
+        let id = Tag::from_str_static("design1");
+        let config = DesignConfig::default();
+        let mut design = Design::new(id, config);
+
+        let run_tag = design.register_invoke_fn(Tag::from_str_static("run_action"), action).unwrap();
+
+        let tag = run_tag.clone();
+        design.add_program("first", move |design, builder| {
+            builder.with_run_action(Invoke::from_tag(&tag, design.config()));
+            Ok(())
+        });
+        let tag = run_tag.clone();
+        design.add_program("second", move |design, builder| {
+            builder.with_run_action(Invoke::from_tag(&tag, design.config()));
+            Ok(())
+        });
+        design.add_program("third", move |design, builder| {
+            builder.with_run_action(Invoke::from_tag(&run_tag, design.config()));
+            Ok(())
+        });
+
+        let mut container = GrowableVec::default();
+        design.into_programs(&GrowableVec::default(), &mut container).unwrap();
+
+        assert_eq!(container.len(), 3);
+        assert_eq!(container[0].name(), "first");
+        assert_eq!(container[1].name(), "second");
+        assert_eq!(container[2].name(), "third");
     }
 
     // TODO add more tests once new Program skeleton is created

--- a/src/orchestration/src/api/design.rs
+++ b/src/orchestration/src/api/design.rs
@@ -191,6 +191,7 @@ impl ProgramData {
 }
 
 #[cfg(test)]
+#[cfg(not(loom))]
 mod tests {
     // Tests are disabled in Miri due to limitations of using OS calls that are done in Iceroxy2 backend.
     // Currently we do not have any constructor that can inject IPC provider (subject to change in the near future).
@@ -285,7 +286,9 @@ mod tests {
         let config = DesignConfig::default();
         let mut design = Design::new(id, config);
 
-        let run_tag = design.register_invoke_fn(Tag::from_str_static("run_action"), action).unwrap();
+        let run_tag = design
+            .register_invoke_fn(Tag::from_str_static("run_action"), action)
+            .unwrap();
 
         let tag = run_tag.clone();
         design.add_program("first", move |design, builder| {

--- a/src/orchestration/src/api/mod.rs
+++ b/src/orchestration/src/api/mod.rs
@@ -166,7 +166,7 @@ impl OrchestrationApi<_DesignTag> {
     /// Returns an error if there is an issue while creating the programs, such as a design not being valid.
     pub fn into_program_manager(mut self) -> Result<OrchProgramManager, CommonErrors> {
         let mut programs = GrowableVec::default();
-        while let Some(design) = self.designs.pop() {
+        while let Some(design) = self.designs.remove(0) {
             design.into_programs(&self.shutdown_events, &mut programs)?
         }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
This PR resolves the issue with `OrchProgramManager` storing programs in reversed order by fixing how designs and programs are drained from their internal storage #60.

Since `Design::into_programs()` and `OrchestrationApi::into_program_manager()` both consumed their internal `GrowableVec` with `pop()`, which removes from the end (LIFO), programs and designs ended up in the reverse of the order they were added, silently breaking any code that relies on `add_program`/`add_design` insertion order.

Proposal:

Currently, `into_programs()` and `into_program_manager()` pop elements off the end of their `GrowableVec`, reversing the original insertion order. This PR updates the drain logic as follows:

Fix Program Order: Change `Design::into_programs()` to drain via `remove(0)` instead of `pop()`, so programs come out in the order they were added.
Fix Design Order: Apply the same fix to `OrchestrationApi::into_program_manager()` for the designs vector.
Add Regression Test: Add `into_programs_preserves_insertion_order`, which registers three programs and asserts they are returned in the same order they were added.

## Pre-Review Checklist for the PR Author

* [x] PR title is short, expressive and meaningful
* [x] Commits are properly organized
* [x] Relevant issues are linked in the [[References](https://github.com/eclipse-score/orchestrator/issues/60)]section
* [x] Tests are conducted
* [x] Unit tests are added

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References


Closes #60 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
